### PR TITLE
[Fix #63] [Fix #106] Missing Consumables Icon on Compass Results Popup

### DIFF
--- a/src/pages/panel/classes/Dashboard.js
+++ b/src/pages/panel/classes/Dashboard.js
@@ -211,6 +211,9 @@ KC3.prototype.Dashboard  = {
 				case 2: iconFile = "../../assets/img/client/ammo.png"; break;
 				case 3: iconFile = "../../assets/img/client/steel.png"; break;
 				case 4: iconFile = "../../assets/img/client/bauxite.png"; break;
+				case 5: iconFile = "../../assets/img/client/ibuild.png"; break;
+				case 6: iconFile = "../../assets/img/client/bucket.png"; break;
+				case 7: iconFile = "../../assets/img/client/devmat.png"; break;
 				default: iconFile = "../../assets/img/client/compass.png"; break;
 			}
 			$("#compassModal .enemyFleet").html("<img src=\""+iconFile+"\" /> "+nodeData.api_itemget.api_getcount);


### PR DESCRIPTION
I found https://kancolletool.github.io/docs/api/
Grinding 2-1 and 2-4 to confirm
Also temporarily changed
`$("#compassModal .enemyFleet").html("<img src=\""+iconFile+"\" /> "+nodeData.api_itemget.api_getcount);`
to
`$("#compassModal .enemyFleet").html("<img src=\""+iconFile+"\" /> "+nodeData.api_itemget.api_icon_id);`

![screen shot 2015-05-25 at 02 21 29](https://cloud.githubusercontent.com/assets/4745298/7789261/ce31a074-0284-11e5-9f00-13d5a11ec239.png)
Only managed to took this one screenshot and even forgot to change it back tho lol