### PR TITLE
[Fix #105] [Bug report] Compass Result: Showing previous result if the next node is a maelstrom

### DIFF
--- a/src/pages/panel/classes/Dashboard.js
+++ b/src/pages/panel/classes/Dashboard.js
@@ -198,13 +198,10 @@ KC3.prototype.Dashboard  = {
 		$("#compassModal").fadeIn(300);
 		$("#compassModal .nodeLetter").text(String.fromCharCode(nodeData.api_no+96).toUpperCase());
 		
-		// Check if enemy node
-		if(typeof nodeData.api_enemy != "undefined"){
+		if (typeof nodeData.api_enemy != "undefined") {              // Check if enemy node
 			$("#compassModal .enemyFleet").text("Enemy #"+nodeData.api_enemy.api_enemy_id);
-		}
-		
-		// Check if resource node
-		if(typeof nodeData.api_itemget != "undefined"){
+            
+		} else if (typeof nodeData.api_itemget != "undefined") {     // Check if resource node
 			var iconFile;
 			switch(nodeData.api_itemget.api_icon_id){
 				case 1: iconFile = "../../assets/img/client/fuel.png"; break;
@@ -217,10 +214,8 @@ KC3.prototype.Dashboard  = {
 				default: iconFile = "../../assets/img/client/compass.png"; break;
 			}
 			$("#compassModal .enemyFleet").html("<img src=\""+iconFile+"\" /> "+nodeData.api_itemget.api_getcount);
-		}
-        
-        // Check if malstrom node
-		if (typeof nodeData.api_happening != "undefined") {
+            
+		} else if (typeof nodeData.api_happening != "undefined") {  // Check if malstrom node
 			var iconFile;
 			switch(nodeData.api_happening.api_icon_id){
 				case 1: iconFile = "../../assets/img/client/fuel.png"; break;
@@ -230,7 +225,10 @@ KC3.prototype.Dashboard  = {
 				default: iconFile = "../../assets/img/client/compass.png"; break;
 			}
 			$("#compassModal .enemyFleet").html("<img src=\""+iconFile+"\" /> -"+nodeData.api_happening.api_count);
-		}
+            
+		} else {
+            $("#compassModal .enemyFleet").html("Battle Avoided");
+        }
 	},
 	
 	/* If a modal is already visible, close it

--- a/src/pages/panel/classes/Dashboard.js
+++ b/src/pages/panel/classes/Dashboard.js
@@ -218,6 +218,19 @@ KC3.prototype.Dashboard  = {
 			}
 			$("#compassModal .enemyFleet").html("<img src=\""+iconFile+"\" /> "+nodeData.api_itemget.api_getcount);
 		}
+        
+        // Check if malstrom node
+		if (typeof nodeData.api_happening != "undefined") {
+			var iconFile;
+			switch(nodeData.api_happening.api_icon_id){
+				case 1: iconFile = "../../assets/img/client/fuel.png"; break;
+				case 2: iconFile = "../../assets/img/client/ammo.png"; break;
+				case 3: iconFile = "../../assets/img/client/steel.png"; break;
+				case 4: iconFile = "../../assets/img/client/bauxite.png"; break;
+				default: iconFile = "../../assets/img/client/compass.png"; break;
+			}
+			$("#compassModal .enemyFleet").html("<img src=\""+iconFile+"\" /> -"+nodeData.api_happening.api_count);
+		}
 	},
 	
 	/* If a modal is already visible, close it


### PR DESCRIPTION
Fixed #105 
@dragonjet 
I tried to investigate a bit and found this nodeData is returned before going into the maelstrom node. I want to help you a bit so I made an attempt to fix this bug by myself.

{
    "api_rashin_flg"    : 1,
    "api_rashin_id"     : 3,
    "api_maparea_id"    : 4,
    "api_mapinfo_no"    : 3,
    "api_no"            : 6,
    "api_color_no"      : 3,
    "api_event_id"      : 3,
    "api_event_kind"    : 0,
    "api_next"          : 1,
    "api_bosscell_no"   : 13,
    "api_bosscomp"      : 1,
    "api_comment_kind"  : 0,
    "api_production_kind":0,
    "api_happening"     : {
            "api_type":1,
            "api_count":20,
            "api_usemst":4,
            "api_mst_id":2,
            "api_icon_id":2,
            "api_dentan":0
    }
}

I am an oversea teitoku, who had a chance to use KanCo! Tools made by you long time ago. I was quite impressed by your work for the community and now I want to contribute to KC3Kai to help others as well. Hope this doesn't bother you. 