### PR TITLE
Equipment Tooltips for Equipment in Strategy Ship Library

### DIFF
--- a/src/pages/strategy/tabs/TabShips.js
+++ b/src/pages/strategy/tabs/TabShips.js
@@ -274,15 +274,22 @@ var TabShips = {
 	/* Show single equipment icon
 	--------------------------------------------*/
 	equipImg :function(cElm, equipNum, gear_id){
-		if(gear_id > -1){
-			if(!app.Gears.get(gear_id)){
-				$(".ship_equip_"+equipNum, cElm).hide();
-				return false;
+		var element = $(".ship_equip_" + equipNum, cElm);
+
+		if (gear_id > -1) {
+			var gear = app.Gears.get(gear_id);
+
+			if(!gear){
+				element.hide();
 			}
-			var MasterGear = app.Master.slotitem(app.Gears.get(gear_id).api_slotitem_id);
-			$(".ship_equip_"+equipNum+" img", cElm).attr("src", "../../assets/img/items/"+MasterGear.api_type[3]+".png");
-		}else{
-			$(".ship_equip_"+equipNum, cElm).hide();
+
+			var masterGear = app.Master.slotitem(gear.api_slotitem_id);
+
+			element.find("img")
+				.attr("src", "../../assets/img/items/" + masterGear.api_type[3] + ".png")
+				.attr("title", masterGear.english + "\n" + masterGear.api_name);
+		} else {
+			element.hide();
 		}
 	}
 	

--- a/src/pages/strategy/tabs/TabShips.js
+++ b/src/pages/strategy/tabs/TabShips.js
@@ -281,6 +281,7 @@ var TabShips = {
 
 			if(!gear){
 				element.hide();
+				return;
 			}
 
 			var masterGear = app.Master.slotitem(gear.api_slotitem_id);


### PR DESCRIPTION
Since tooltips for the ship equipment was added to the panel, I thought maybe it should be added to the strategy room ship library so it would be a similar user experience.