### PR TITLE
New feature: adding expedition task helper

### DIFF
--- a/src/pages/panel/themes/horizontal.html
+++ b/src/pages/panel/themes/horizontal.html
@@ -362,6 +362,8 @@
 				</div>
 				<div class="clear"></div>
 			</div>
+                        <div class="expedition-estimate">
+                        </div>
 		</div>
 	</div>
 	

--- a/src/pages/panel/views/Dashboard.Fleet.js
+++ b/src/pages/panel/views/Dashboard.Fleet.js
@@ -1,3 +1,238 @@
+KC3.prototype.ExpeditionHelper = {
+    preconds: {
+        1: function(info) {
+            return info.shipCount >= 2
+                && info.flagShipLevel >= 1;
+        },
+        2: function(info) {
+            return info.shipCount >= 4
+                && info.flagShipLevel >= 2;
+        },
+        3: function(info) {
+            return info.shipCount >= 3
+                && info.flagShipLevel >= 3;
+        },
+        4: function(info) {
+            return info.shipCount >= 3
+                && info.flagShipLevel >= 3
+                && info.queryStype("CL").length >= 1
+                && info.queryStype("DD").length >= 2;
+        },
+        5: function(info) {
+            return info.shipCount >= 4
+                && info.flagShipLevel >= 3
+                && info.queryStype("CL").length >= 1
+                && info.queryStype("DD").length >= 2;
+        },
+        6: function(info) {
+            return info.shipCount >= 4
+                && info.flagShipLevel >= 4;
+        },
+        7: function(info) {
+            return info.shipCount >= 6
+                && info.flagShipLevel >= 5;
+        },
+        8: function(info) {
+            return info.shipCount >= 6
+                && info.flagShipLevel >= 6;
+        },
+        9: function(info) {
+            return info.shipCount >= 4
+                && info.flagShipLevel >= 3
+                && info.queryStype("CL").length >= 1
+                && info.queryStype("DD").length >= 2;
+        },
+        10: function(info) {
+            return info.shipCount >= 3
+                && info.queryStype("CL").length >= 2;
+        },
+        11: function(info) {
+            return info.shipCount >= 4
+                && info.flagShipLevel >= 6
+                && info.queryStype("DD").length >= 2;
+        },
+        12: function(info) {
+            return info.shipCount >= 4
+                && info.flagShipLevel >= 4
+                && info.queryStype("DD").length >= 2;
+        },
+        13: function(info) {
+            return info.shipCount >= 6
+                && info.flagShipLevel >= 5
+                && info.queryStype("CL").length >= 1
+                && info.queryStype("DD").length >= 4;
+        },
+        14: function(info) {
+            return info.shipCount >= 6
+                && info.flagShipLevel >= 6
+                && info.queryStype("CL").length >= 1
+                && info.queryStype("DD").length >= 3;
+        },
+        15: function(info) {
+            return info.shipCount >= 6
+                && info.flagShipLevel >= 9
+                && info.queryStype("CV CVL AV").length >= 2
+                && info.queryStype("DD").length >= 2;
+        },
+        16: function(info) {
+            return info.shipCount >= 6
+                && info.flagShipLevel >= 11
+                && info.queryStype("CL").length >= 1
+                && info.queryStype("DD").length >= 2;
+        },
+        17: function(info) {
+            return info.shipCount >= 6
+                && info.flagShipLevel >= 20
+                && info.queryStype("CL").length >= 1
+                && info.queryStype("DD").length >= 3;
+        },
+        18: function(info) {
+            return info.shipCount >= 6
+                && info.flagShipLevel >= 15
+                && info.queryStype("CV CVL AV").length >= 3
+                && info.queryStype("DD").length >= 2;
+        },
+        19: function(info) {
+            return info.shipCount >= 6
+                && info.flagShipLevel >= 20
+                && info.queryStype("BBV").length >= 2
+                && info.queryStype("DD").length >= 2;
+        },
+        20: function(info) {
+            return info.shipCount >= 2
+                && info.flagShipLevel >= 1
+                && info.queryStype("SS SSV").length >= 1
+                && info.queryStype("CL").length >= 1;
+        },
+        21: function(info) {
+            var isDrumEquipped = KC3.prototype.ExpeditionHelper.utils.isDrumEquipped;
+            return $.grep(info.ships, isDrumEquipped).length >= 3
+                && info.shipCount >= 5
+                && info.flagShipLevel >= 15
+                && info.shipLevelCount >= 30
+                && info.queryStype("CL").length >= 1
+                && info.queryStype("DD").length >= 4;
+        },
+        22: function(info) {
+            return info.shipCount >= 6
+                && info.flagShipLevel >= 30
+                && info.shipLevelCount >= 45
+                && info.queryStype("CA").length >= 1
+                && info.queryStype("CL").length >= 1
+                && info.queryStype("DD").length >= 2;
+        },
+        23: function(info) {
+            return info.shipCount >= 6
+                && info.flagShipLevel >= 50
+                && info.shipLevelCount >= 200
+                && info.queryStype("BBV").length >= 2
+                && info.queryStype("DD").length >= 2;
+        },
+        24: function(info) {
+            return info.shipCount >= 6
+                && info.flagShipLevel >= 50
+                && info.shipLevelCount >= 200
+                && info.flagShip.stypeIsOneOf("CL")
+                && info.queryStype("CL").length >= 1
+                && info.queryStype("DD").length >= 4;
+        }
+    },
+    analyzeFleet: function(fleetShipIds) {
+        var u = KC3.prototype.ExpeditionHelper.utils;
+        var preconds = KC3.prototype.ExpeditionHelper.preconds;
+        var validFleetShipIds = $.grep(fleetShipIds, function(v) { return v > 0; });
+
+        if (validFleetShipIds.length) {
+            var avaExps = [];
+            var fleetInfo = u.collectFleetInfo(validFleetShipIds);
+            for (var expNum in preconds) {
+                if (preconds.hasOwnProperty(expNum) && u.isInt(expNum)) {
+                    if (preconds[expNum](fleetInfo)) {
+                        avaExps.push(expNum);
+                    }
+                }
+            }
+
+            var warnings = [];
+            // check bullet and fuel
+            // might not be necessary, but we'd better ensure it is full.
+            var isBulletAndFuelFull = function(ship) {
+                var shipInst = ship.inst;
+                var shipModel = ship.model;
+                return shipInst.api_fuel == shipModel.api_fuel_max
+                    && shipInst.api_bull == shipModel.api_bull_max;
+            }
+            for (var sInd in fleetInfo.ships) {
+                if (!isBulletAndFuelFull(fleetInfo.ships[sInd])) {
+                    warnings.push( "bullet or fuel is not full" );
+                    break;
+                }
+            } 
+            // check morale
+            // TODO: this might depend on the expedition task
+            // the lower bound is not yet confirmed, but I think >= 39 will be fine
+            for (var sInd in fleetInfo.ships) {
+                if (fleetInfo.ships[sInd].inst.api_cond <= 39) {
+                    warnings.push( "morale of some ships are less than 39" );
+                    break;
+                }
+            }
+            return { availableExpedition: avaExps,
+                     warnings: warnings
+                   };
+        } else {
+            return "expedition advice not available.";
+        }
+    },
+    utils: {
+        isInt: function(v) {
+            return !isNaN(v) 
+                &&  parseInt(Number(v)) == v
+                && !isNaN(parseInt(v, 10));
+        },
+        isDrumEquipped: function(ship) {
+            var shipInst = ship.inst;
+            for (var slot in [0,1,2,3]) {
+                gear_id = shipInst.api_slot[slot];
+                thisItem = app.Gears.get(gear_id);
+                if (thisItem) {
+                    model = app.Master.slotitem(thisItem.api_slotitem_id);
+                    if (model.api_id == 75)
+                        return true;
+                }
+            }
+            return false;
+        },
+        collectFleetInfo: function(validFleetShipIds) {
+            var shipLevelCount = 0;
+            var ships = validFleetShipIds.map(function(s) {
+                var shipInst = app.Ships.get(s);
+                var shipModel = app.Master.ship(shipInst.api_ship_id);
+                var stypeIsOneOf = function(queryRaw) {
+                    var stype = app.Meta.stype(shipModel.api_stype)
+                    var alts = queryRaw.split(" ");
+                    return $.inArray(stype,alts) > -1;
+                };
+                shipLevelCount += shipInst.api_lv;
+                return { inst: shipInst,
+                         model: shipModel,
+                         stypeIsOneOf: stypeIsOneOf};
+            });
+            return { ships: ships,
+                     shipCount: ships.length,
+                     shipLevelCount: shipLevelCount,
+                     queryStype: function(query) {
+                         return $.grep(ships, function(s) {
+                             return s.stypeIsOneOf(query);
+                         });
+                     },
+                     flagShip: ships[0],
+                     flagShipLevel: ships[0].inst.api_lv
+                   };
+        }
+    }
+};
+
 KC3.prototype.Dashboard.Fleet = {
 	selectedFleet: 1,
 	currentShipLos: 0,
@@ -33,6 +268,9 @@ KC3.prototype.Dashboard.Fleet = {
 		$(".fleet-summary .summary-eqlos .summary-text").text(app.Fleet.getEffectiveLoS());
 		$(".fleet-summary .summary-airfp .summary-text").text(app.Fleet.fighter_power);
 		$(".fleet-summary .summary-speed .summary-text").text(app.Fleet.speed);
+            
+                var expeditionAdvice = app.ExpeditionHelper.analyzeFleet(fleetShipIds);
+                $(".expedition-estimate").text(JSON.stringify(expeditionAdvice));
 	},
 	
 	ship :function(index, ship_id, animateID){


### PR DESCRIPTION
I hacked the extension a little bit to show a list of expedition tasks current fleet might be able to do.
Some warning info is also included indicating the morale status and whether bullet and fuel are full.
Please see the screenshot.

![2015-06-16_181403_3360x1080_scrot](https://cloud.githubusercontent.com/assets/1096354/8195935/59cfd980-1454-11e5-8d34-b6ee9c5cf1ad.png)

I'm not proficient at web app development and sorry for not being able to make it look better.
For now only Expedition#1 ~ Expedition#24 are supported, I'm still new to KanColle so some of these expedition predicates are yet to be verified.

I still need some free time finishing up supports for the remaining expedition tasks,
just opening an early PR to see if you like this feature :)

