### PR TITLE
[Fix] Compass result for enemy fleet doesn't work

### DIFF
--- a/src/library/classes/Assets.js
+++ b/src/library/classes/Assets.js
@@ -1,5 +1,6 @@
 KC3.prototype.Assets = {
 	cdn: "http://i708.photobucket.com/albums/ww87/dragonjet25/KC3%20Ship%20Icons/",
+	abyss: "http://i708.photobucket.com/albums/ww87/dragonjet25/KC3%20Abyss%20Icons/",
 	_ships :[],
 	
 	init :function(repo){
@@ -10,6 +11,14 @@ KC3.prototype.Assets = {
 	shipIcon :function(id, empty){
 		if(typeof this._ships[id] !== "undefined"){
 			return this.cdn + this._ships[id];
+		}else{
+			return empty;
+		}
+	},
+	
+	abyssIcon :function(id, empty){
+		if(typeof this._ships[id] !== "undefined"){
+			return this.abyss + this._ships[id];
 		}else{
 			return empty;
 		}

--- a/src/pages/panel/classes/Dashboard.js
+++ b/src/pages/panel/classes/Dashboard.js
@@ -198,9 +198,10 @@ KC3.prototype.Dashboard  = {
 		$("#compassModal").fadeIn(300);
 		$("#compassModal .nodeLetter").text(String.fromCharCode(nodeData.api_no+96).toUpperCase());
 		
-		$("#compassModal .enemyFleet").html("");
+		$("#compassModal .enemy-label").html("");
+		$("#compassModal .enemy-formation").html("");
+		$("#compassModal .enemy-ships").html("");
 		$("#compassModal .itemGet").html("");
-		
 		
 		if (typeof nodeData.api_enemy != "undefined") {              // Check if enemy node
 			var mapArea = nodeData.api_maparea_id;
@@ -211,25 +212,21 @@ KC3.prototype.Dashboard  = {
 			
 			app.Logging.get_battle(mapArea, mapNo, battleNode, enemyId, function(battle){
 				if (battle) {
-					enemyText += "<img src=\"../../assets/img/formation/" + battle.data.api_formation[1] + ".jpg\"/><br>";
+					$("#compassModal .enemy-formation").html("<img src=\"../../assets/img/formation/" + battle.data.api_formation[1] + ".jpg\"/>");
 					for (var i = 1; i <= 6; i++) {
 						if (battle.data.api_ship_ke[i] > -1) {
-							enemyText += "<img class=\"enemy-img\" src=\"../../assets/img/abyssal/" + battle.data.api_ship_ke[i] + ".png\" alt=\"" + battle.data.api_ship_ke[i] + "\"/>";
+							enemyUrl = app.Assets.abyssIcon(battle.data.api_ship_ke[i], "");
+							enemyText += "<img class=\"enemy-img\" src=\"" + enemyUrl + "\" alt=\"" + battle.data.api_ship_ke[i] + "\"/>";
 						}
 						if (i==3) {
 							enemyText += "<br>";
 						}
 					}
 				} else {
-					for (var i = 1; i <= 6; i++) {
-						enemyText += "<img class=\"enemy-img\" src=\"../../assets/img/abyssal/Unknown.png\" alt=\"Unknown\"/>";
-						if (i==3) {
-							enemyText += "<br>";
-						}
-					}
+					enemyText = "Unknown Enemy";
 				}
-				$("#compassModal .enemyFleet").html("Enemy #" + nodeData.api_enemy.api_enemy_id + "<br>" + enemyText);
-				//$("#compassModal .enemyFleet").html(enemyText);
+				//$("#compassModal .enemy-label").html("Enemy #" + nodeData.api_enemy.api_enemy_id);
+				$("#compassModal .enemy-ships").html(enemyText);
 			});
 			
 		} else if (typeof nodeData.api_itemget != "undefined") {     // Check if resource node
@@ -272,7 +269,7 @@ KC3.prototype.Dashboard  = {
 			$("#compassModal .itemGet").html("<img src=\""+iconFile+"\" /> -"+nodeData.api_happening.api_count);
 			
 		} else {
-			$("#compassModal .enemyFleet").html("Battle Avoided");
+			$("#compassModal .enemy-label").html("Battle Avoided");
 		}
 	},
 	

--- a/src/pages/panel/panel.css
+++ b/src/pages/panel/panel.css
@@ -286,6 +286,19 @@ html,body {
 	font-size:14px;
 	text-align:center;
 }
+
+#compassModal .enemy-formation img {
+	margin: 20px 20px 20px 20px;
+}
+
+#compassModal .enemyFleet .enemy-img {
+	width:35px;
+	height:35px;
+	border-radius:35px;
+	border:2px solid #aaa;
+	margin: 5px 5px 5px 5px;
+}
+
 #compassModal .itemGet {
 	width:240px;
 	height:30px;
@@ -293,10 +306,6 @@ html,body {
 	font-size:14px;
 	text-align:center;
 	margin-top:-40px;
-}
-#compassModal .enemyFleet .enemy-img {
-	width:80px;
-	height:20px;
 }
 
 /* PANEL

--- a/src/pages/panel/panel.html
+++ b/src/pages/panel/panel.html
@@ -86,7 +86,19 @@
 					<div class="compassBox"></div>
 					<div class="transparent-container">
 						<div class="nodeLetter"></div>
-						<div class="enemyFleet"></div>
+						<div class="enemyFleet">
+							<table>
+								<tr>
+									<td colspan="2">
+										<span class="enemy-label"></span>
+									</td>
+								</tr>
+								<tr>
+									<td class="enemy-formation"></td>
+									<td class="enemy-ships"></td>
+								</tr>
+							</table>
+						</div>
 						<div class="itemGet"></div>
 					</div>
 				</div>


### PR DESCRIPTION
I noticed after moving the Abyssal images to photobucket, the compass cannot show the enemy fleet image anymore so I made a fix for it. Now it looks like this.

![untitled](https://cloud.githubusercontent.com/assets/8078323/8231178/b402cfee-1601-11e5-9894-dd50d1b9e028.png)
