### PR TITLE
Fix bug show color in BattleModal

### DIFF
--- a/src/pages/panel/classes/Dashboard.js
+++ b/src/pages/panel/classes/Dashboard.js
@@ -201,6 +201,9 @@ KC3.prototype.Dashboard  = {
 		$("#modals").fadeIn(300);
 		$("#battleModal").fadeIn(300);
 		
+		$("#battleModal .battle-value").removeClass("good");
+		$("#battleModal .battle-value").removeClass("bad");
+		
 		// Show detection
 		var detection = app.Meta.detection(battleData.api_search[0]);
 		$("#battleModal #detect").html( "&nbsp;" + detection[0] );


### PR DESCRIPTION
Previously, before adding the class "good" or "bad" to change the color of the text, I forgot to remove them out so the "Air Supremacy" sometimes can have the red color (instead of green) if the air battle was bad in the previous battle xD