### PR TITLE
[Fix #188] BETA Ship on KC3Kai panel bugged

### DIFF
--- a/src/library/modules/Kcsapi.js
+++ b/src/library/modules/Kcsapi.js
@@ -698,8 +698,8 @@ Previously known as "Reactor"
 				KC3QuestManager.get(702).increment(); // G2: Daily Modernization
 				KC3QuestManager.get(703).increment(); // G3: Weekly Modernization
 				KC3Network.trigger("Quests");
-				KC3Network.trigger("Fleet");
 			}
+			KC3Network.trigger("Fleet");
 		},
 		
 		/* Equipment Modernize


### PR DESCRIPTION
Fix #188

Sorry for no video but it works for me now. The chosen ships still disappear regardless success or failure. Feel free to report if the issue still happens.