### PR TITLE
"font-size" for ".settingBox .note" is prohibited.

### DIFF
--- a/src/pages/settings/settings.css
+++ b/src/pages/settings/settings.css
@@ -126,7 +126,7 @@ body {
 	line-height:40px;
 	float:left;
 	text-align:center;
-	font-size:16px;
+	/*font-size:16px;*/
 	font-weight:bold;
 	color:#009900;
 	display:none;


### PR DESCRIPTION
Its font size, 16px, is too large for "保存する！" (Saved!) word for now.