### PR TITLE
[Feature #342] Added tooltip for quest status and quest description

### DIFF
--- a/src/library/objects/Quest.js
+++ b/src/library/objects/Quest.js
@@ -56,16 +56,28 @@ Quest Type:
 	};
 	
 	/* OUTPUT SHORT
-	Return tracking text to be shown on Strategy Room
+	Return tracking text to be shown on Panel
 	------------------------------------------*/
-	KC3Quest.prototype.outputShort = function(){
+	KC3Quest.prototype.outputShort = function(showAll){
+		if (typeof showAll == "undefined") {
+			showAll = false;
+		}
 		if(this.tracking){
 			var trackingText = [];
 			var ctr;
+			var textToShow = "";
 			for(ctr in this.tracking){
-				trackingText.push(this.tracking[ctr][0]+"/"+this.tracking[ctr][1]);
+				textToShow = this.tracking[ctr][0]+"/"+this.tracking[ctr][1];
+				trackingText.push(textToShow);
+				if (!showAll && (this.tracking[ctr][0] < this.tracking[ctr][1])) {
+					return textToShow;
+				}
 			}
-			return trackingText.join(", ");
+			if (!showAll) {
+				return textToShow;
+			} else {
+				return trackingText.join(String.fromCharCode(13));
+			}
 		}
 		return "";
 	};

--- a/src/pages/devtools/themes/default/horizontal/horizontal.js
+++ b/src/pages/devtools/themes/default/horizontal/horizontal.js
@@ -203,10 +203,12 @@
 						$(".box-quests .quest-box-"+(index+1)+" .color", container).addClass( "type"+questType );
 						if(quest.meta){
 							$(".box-quests .quest-box-"+(index+1)+" .name div", container).text( quest.meta().name );
+							$(".box-quests .quest-box-"+(index+1)+" .name", container).attr("title", quest.meta().desc );
 						}else{
 							$(".box-quests .quest-box-"+(index+1)+" .name div", container).text("?");
 						}
 						$(".box-quests .quest-box-"+(index+1)+" .status", container).text( quest.outputShort() );
+						$(".box-quests .quest-box-"+(index+1)+" .status", container).attr("title", quest.outputShort(true) );
 						$(".box-quests .quest-box-"+(index+1), container).show();
 					});
 					
@@ -226,10 +228,12 @@
 						$(".battle_quests .quest-box-"+(index+1)+" .color", container).addClass( "type"+questType );
 						if(quest.meta){
 							$(".battle_quests .quest-box-"+(index+1)+" .name div", container).text( quest.meta().name );
+							$(".battle_quests .quest-box-"+(index+1)+" .name div", container).attr("title", quest.meta().desc );
 						}else{
 							$(".battle_quests .quest-box-"+(index+1)+" .name div", container).text("?");
 						}
 						$(".battle_quests .quest-box-"+(index+1)+" .status", container).text( quest.outputShort() );
+						$(".battle_quests .quest-box-"+(index+1)+" .status", container).attr("title", quest.outputShort(true) );
 						$(".battle_quests .quest-box-"+(index+1), container).show();
 					});
 				}

--- a/src/pages/devtools/themes/default/vertical/vertical.js
+++ b/src/pages/devtools/themes/default/vertical/vertical.js
@@ -297,10 +297,12 @@
 						$(".box-quests .quest-box-"+(index+1)+" .color", container).addClass( "type"+questType );
 						if(quest.meta){
 							$(".box-quests .quest-box-"+(index+1)+" .name", container).text( quest.meta().name );
+							$(".box-quests .quest-box-"+(index+1)+" .name", container).attr("title", quest.meta().desc );
 						}else{
 							$(".box-quests .quest-box-"+(index+1)+" .name", container).text("?");
 						}
 						$(".box-quests .quest-box-"+(index+1)+" .status", container).text( quest.outputShort() );
+						$(".box-quests .quest-box-"+(index+1)+" .status", container).attr("title", quest.outputShort(true) );
 						$(".box-quests .quest-box-"+(index+1), container).show();
 					});
 					
@@ -320,10 +322,12 @@
 						$(".battle_quests .quest-box-"+(index+1)+" .color", container).addClass( "type"+questType );
 						if(quest.meta){
 							$(".battle_quests .quest-box-"+(index+1)+" .name", container).text( quest.meta().name );
+							$(".battle_quests .quest-box-"+(index+1)+" .name", container).attr("title", quest.meta().desc );
 						}else{
 							$(".battle_quests .quest-box-"+(index+1)+" .name", container).text("?");
 						}
 						$(".battle_quests .quest-box-"+(index+1)+" .status", container).text( quest.outputShort() );
+						$(".battle_quests .quest-box-"+(index+1)+" .status", container).attr("title", quest.outputShort(true) );
 						$(".battle_quests .quest-box-"+(index+1), container).show();
 					});
 				}


### PR DESCRIPTION
resolved #342 
* hide fulfilled conditions (except it's the last one), show the next "not-fulfilled" condition if available
* added tooltip for quest status and quest description in both `horizontal.js` and `vertical.js`

![screen shot 2015-07-24 at 5 32 42 am](https://cloud.githubusercontent.com/assets/8078323/8862841/57f0812a-31c6-11e5-90da-459a0ce2e0e1.png)

![screen shot 2015-07-24 at 5 32 44 am](https://cloud.githubusercontent.com/assets/8078323/8862842/5b217124-31c6-11e5-8184-8e54cfebcfcf.png)