### PR TITLE
[English] [Terms] Adding name for `SettingsGearHolder`.

### DIFF
--- a/src/data/translations/en/terms.json
+++ b/src/data/translations/en/terms.json
@@ -129,9 +129,12 @@
 	
 	"SettingsPanelSize" : "Panel Size",
 	"SettingsPanelOpacity" : "Interface Opacity",
+	"SettingsGearHolder" : "Gear Background Color",
 	
 	"Small" : "Small",
 	"Big" : "Big",
+	"Black" : "Black",
+	"White" : "White",
 	"Theme" : "Theme",
 	"Panel" : "Panel",
 	"Volume" : "Volume",


### PR DESCRIPTION
`SettingsGearHolder` as "Gear Background Color", also `Black` and `White`.