### PR TITLE
It was "-A" instead of " A" for Chitose-class remodels

### DIFF
--- a/src/pages/strategy/tabs/wikia/wikia.js
+++ b/src/pages/strategy/tabs/wikia/wikia.js
@@ -43,7 +43,7 @@
 
       // Special case because Chiyoda and Chitose have an "A" remodel which could be part of a name
       if(api_name.substr(0, 7) == 'Chiyoda' || api_name.substr(0, 7) == 'Chitose') {
-        base_name = base_name.replace(' A', '');
+        base_name = base_name.replace('-A', '');
       }
 
       var remodel = api_name.split(base_name + ' ')[1] || '';


### PR DESCRIPTION
Minor fix required to prevent it from being "Chitose-A/" instead of "Chitose/A".