### PR TITLE
Update event map HP when starting sortie

### DIFF
--- a/src/library/modules/Kcsapi.js
+++ b/src/library/modules/Kcsapi.js
@@ -447,6 +447,17 @@ Previously known as "Reactor"
 			
 			KC3QuestManager.get(214).increment(0); // Bw1: 1st requirement: Sortie 36 times (index:0)
 			
+			if (typeof response.api_data.api_eventmap !== "undefined") {
+				var AllMaps = JSON.parse(localStorage.maps);
+				var thisMapId = "m"+response.api_data.api_maparea_id+""+response.api_data.api_mapinfo_no;
+				var thisMap = AllMaps[thisMapId];
+
+				thisMap.curhp = response.api_data.api_eventmap.api_now_maphp;
+				thisMap.maxhp = response.api_data.api_eventmap.api_max_maphp;
+
+				localStorage.maps = JSON.stringify(AllMaps);
+			}
+
 			KC3SortieManager.advanceNode( response.api_data, UTCTime );
 			
 			KC3Network.trigger("SortieStart");


### PR DESCRIPTION
When we navigate through the map list (`\mapinfo`), it will tell us the HP of the map is 9999 but then when we start the sortie (`\start`), it will show the true HP of the map. So this fix is to get the second one.