### PR TITLE
[Feature #587] [Suggestion] Add enemy flagship boss's armor stats.

### DIFF
--- a/src/library/objects/Node.js
+++ b/src/library/objects/Node.js
@@ -94,7 +94,8 @@ Used by SortieManager
 		if(enemyships[0]==-1){ enemyships.splice(0,1); }
 		this.eships = enemyships;
 		this.eformation = battleData.api_formation[1];
-		
+		this.eParam = battleData.api_eParam;
+
 		this.supportFlag = (battleData.api_support_flag>0);
 		this.yasenFlag = (battleData.api_midnight_flag>0);
 		

--- a/src/pages/devtools/themes/natsuiro/natsuiro.js
+++ b/src/pages/devtools/themes/natsuiro/natsuiro.js
@@ -217,6 +217,7 @@
 	
 	function clearBattleData(){
 		$(".module.activity .abyss_ship img").attr("src", KC3Meta.abyssIcon(-1));
+		$(".module.activity .abyss_ship img").attr("title", "");
 		$(".module.activity .abyss_ship").css("opacity", 1);
 		$(".module.activity .abyss_ship").hide();
 		$(".module.activity .abyss_hp").hide();
@@ -517,8 +518,17 @@
 			
 			// Load enemy icons
 			$.each(thisNode.eships, function(index, eshipId){
+				var eParam = thisNode.eParam[index];
+				
 				if(eshipId > -1){
 					$(".module.activity .abyss_ship_"+(index+1)+" img").attr("src", KC3Meta.abyssIcon(eshipId));
+
+					var tooltip = "FP: " + eParam[0] + String.fromCharCode(13);
+					tooltip += "Torp: " + eParam[1] + String.fromCharCode(13);
+					tooltip += "AA: " + eParam[2] + String.fromCharCode(13);
+					tooltip += "Armor: " + eParam[3];
+					
+					$(".module.activity .abyss_ship_"+(index+1)+" img").attr("title", tooltip);
 					$(".module.activity .abyss_ship_"+(index+1)).show();
 				}
 			});
@@ -738,8 +748,16 @@
 			// Show opponent ships faces
 			console.log(thisPvP.eships);
 			$.each(thisPvP.eships, function(index, eshipId){
+				var eParam = thisPvP.eParam[index];
+				
 				if(eshipId > -1){
 					$(".module.activity .abyss_ship_"+(index+1)+" img").attr("src", KC3Meta.shipIcon(eshipId));
+					var tooltip = "FP: " + eParam[0] + String.fromCharCode(13);
+					tooltip += "Torp: " + eParam[1] + String.fromCharCode(13);
+					tooltip += "AA: " + eParam[2] + String.fromCharCode(13);
+					tooltip += "Armor: " + eParam[3];
+					
+					$(".module.activity .abyss_ship_"+(index+1)+" img").attr("title", tooltip);
 					$(".module.activity .abyss_ship_"+(index+1)).show();
 				}
 			});


### PR DESCRIPTION
resolved #587 
Added tooltip for enemy ships, showing their FP, torpedo, AA and Armor

![screen shot 2015-08-12 at 12 54 36 pm](https://cloud.githubusercontent.com/assets/8078323/9216820/de57c734-40f1-11e5-8462-f434fd83f609.png)
