### PR TITLE
Timer toggle

### DIFF
--- a/src/assets/js/global.js
+++ b/src/assets/js/global.js
@@ -154,6 +154,23 @@ String.prototype.toHHMMSS = function () {
     return time;
 };
 
+/* SECONDS TO HH:MM:SS, ADDING CURRENT TIME
+ * TODO: Currently does not handle intervals greater than 24 hours well.
+ *       Possibly fix by prepending the date if secondsRemaining is big enough
+ *       to be confusing.
+-------------------------------*/
+String.prototype.plusCurrentTime = function() {
+    var currentTime = new Date();
+    var secondsAfterMidnight = 
+        3600 * currentTime.getHours() +
+        60   * currentTime.getMinutes() +
+               currentTime.getSeconds();
+
+    var secondsRemaining = parseInt(this, 10);
+    var timeFinished = secondsAfterMidnight + secondsRemaining;
+    return String(timeFinished).toHHMMSS();
+}
+
 
 /* GOOGLE ANALYTICS
 -------------------------------*/

--- a/src/assets/js/global.js
+++ b/src/assets/js/global.js
@@ -169,7 +169,7 @@ String.prototype.plusCurrentTime = function() {
     var secondsRemaining = parseInt(this, 10);
     var timeFinished = secondsAfterMidnight + secondsRemaining;
     return String(timeFinished).toHHMMSS();
-}
+};
 
 
 /* GOOGLE ANALYTICS

--- a/src/data/settings.json
+++ b/src/data/settings.json
@@ -47,6 +47,17 @@
 						[ 3, "SettingsHQExpTotal" ]
 					]
 				}
+			},
+			{
+				"id": "timerDisplayType",
+				"name": "SettingsTimerDisplayType",
+				"type": "radio",
+				"options" : {
+					"choices" : [
+						[ 1, "SettingsTimeRemaining" ],
+						[ 2, "SettingsTimeFinished" ]
+					]
+				}
 			}
 		]
 	},

--- a/src/library/managers/ConfigManager.js
+++ b/src/library/managers/ConfigManager.js
@@ -17,6 +17,7 @@ Retreives when needed to apply on components
 				language			: "en",
 				elosFormula 		: 3,
 				hqExpDetail 		: 1,
+				timerDisplayType	: 1,
 				marryLevelFormat: 0,
 				
 				info_face 			: true,
@@ -112,6 +113,12 @@ Retreives when needed to apply on components
 		// Toggle HQ Exp Information
 		scrollHQExpInfo :function(){
 			this.hqExpDetail = (this.hqExpDetail % 3) + 1;
+			this.save();
+		},
+		
+		// Toggle repair timer type
+		scrollTimerType :function(){
+			this.timerDisplayType = (this.timerDisplayType % 2) + 1;
 			this.save();
 		}
 		

--- a/src/pages/devtools/themes/natsuiro/natsuiro.js
+++ b/src/pages/devtools/themes/natsuiro/natsuiro.js
@@ -77,6 +77,36 @@
 			ConfigManager.scrollElosMode();
 			$(".summary-eqlos .summary_icon img").attr("src", "../../../../assets/img/stats/"+["lsc","lst","lse","ls"][ConfigManager.elosFormula]+".png");			$(".summary-eqlos .summary_text").text( Math.round(((selectedFleet < 5) ? PlayerManager.fleets[selectedFleet-1].eLoS() : PlayerManager.fleets[0].eLoS()+PlayerManager.fleets[1].eLoS()) * 100) / 100 );
 		}).addClass("hover");
+
+		// Timer Type Toggle
+		$(".status_docking").on("click",function(){
+			ConfigManager.scrollTimerType();
+			var docking, akashi;
+			if (selectedFleet < 5){
+			    docking = PlayerManager.fleets[selectedFleet - 1].highestRepairTimes().docking;
+			    akashi = PlayerManager.fleets[selectedFleet - 1].highestRepairTimes().akashi;
+			}else{
+			    var MainRepairs = PlayerManager.fleets[0].highestRepairTimes();
+			    var EscortRepairs = PlayerManager.fleets[1].highestRepairTimes();
+			    docking = (MainRepairs.docking > EscortRepairs.docking) ? MainRepairs.docking : EscortRepairs.docking;
+			    akashi = (MainRepairs.akashi > EscortRepairs.akashi) ? MainRepairs.akashi : EscortRepairs.akashi;
+			}
+			UpdateRepairTimerDisplays(docking, akashi);
+		}).addClass("hover");
+		$(".status_akashi").on("click",function(){
+			ConfigManager.scrollTimerType();
+			var docking, akashi;
+			if (selectedFleet < 5){
+			    docking = PlayerManager.fleets[selectedFleet - 1].highestRepairTimes().docking;
+			    akashi = PlayerManager.fleets[selectedFleet - 1].highestRepairTimes().akashi;
+			}else{
+			    var MainRepairs = PlayerManager.fleets[0].highestRepairTimes();
+			    var EscortRepairs = PlayerManager.fleets[1].highestRepairTimes();
+			    docking = (MainRepairs.docking > EscortRepairs.docking) ? MainRepairs.docking : EscortRepairs.docking;
+			    akashi = (MainRepairs.akashi > EscortRepairs.akashi) ? MainRepairs.akashi : EscortRepairs.akashi;
+			}
+			UpdateRepairTimerDisplays(docking, akashi);
+		}).addClass("hover");
 		
 		// Screenshot buttons
 		$(".module.controls .btn_ss1").on("click", function(){
@@ -562,8 +592,7 @@
 			$(".module.status .status_support .status_text").text( FleetSummary.supportPower );
 			
 			// STATUS: REPAIRS
-			$(".module.status .status_docking .status_text").text(String(FleetSummary.docking).toHHMMSS());
-			$(".module.status .status_akashi .status_text").text(String(FleetSummary.akashi).toHHMMSS());
+			UpdateRepairTimerDisplays(FleetSummary.docking, FleetSummary.akashi);
 			$(".module.status .status_docking").attr("title", KC3Meta.term("PanelHighestDocking") );
 			$(".module.status .status_akashi").attr("title", KC3Meta.term("PanelHighestAkashi") );
 			$(".module.status .status_support").attr("title", KC3Meta.term("PanelSupportPower") );
@@ -1108,6 +1137,18 @@
 			
 			$("img", thisStatBox).attr("src", "../../../../assets/img/stats/"+Code+".png");
 			$(".equipStatText", thisStatBox).text( MasterItem["api_"+StatProperty] );
+		}
+	}
+	function UpdateRepairTimerDisplays(docking, akashi){
+		switch (ConfigManager.timerDisplayType) {
+		case 1:
+			$(".module.status .status_docking .status_text").text("-" + String(docking).toHHMMSS());
+			$(".module.status .status_akashi .status_text").text("-" + String(akashi).toHHMMSS());
+			break;
+		case 2:
+			$(".module.status .status_docking .status_text").text(String(docking).plusCurrentTime());
+			$(".module.status .status_akashi .status_text").text(String(akashi).plusCurrentTime());
+			break;
 		}
 	}
 	


### PR DESCRIPTION
Cf. issue #748.

Everything seems to be working correctly, but there are a couple of places I'm not sure how we want to proceed.

1. Displaying the estimated time of completion for repairs currently doesn't play nice with repair times longer than 24 hours.  If it's 10 a.m. right now and Akagi needs 40 hours to repair, it'll just say "04:00" without specifying that it's 4 a.m. two days from now.

2. There is some potential ambiguity between duration and expected time of completion.  Currently what I have done is add a minus sign ("-02:30") to indicate remaining repair time and no such mark if time of day is being displayed instead.

3. Right now I'm displaying the current time when there are no repairs needed, but since the time display doesn't update as the clock ticks, it might look weird to have KC3Kai say that the repairs are expected to finish "a few minutes ago".  One option would be to replace the text with "N/A" or something else indicating that no repairs are necessary.

Please let me know if you have any other suggestions and I'll try to implement them.